### PR TITLE
`yarn storybook` 実行時の警告を抑制する

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -4,6 +4,10 @@
     [
       "styled-components",
       { "ssr": true, "displayName": true, "preprocess": false }
+    ],
+    [
+      "@babel/plugin-proposal-private-property-in-object",
+      { "loose": true }
     ]
   ]
 }


### PR DESCRIPTION
# issue
作成してませんが、必要であれば作成しますのでコメントください。

# 概要
* `yarn storybook` 実行時(初回のみ)に警告がでるようなので抑制したい
*  node_modules配下の依存パッケージに対して発生している

```
node_modules/xxxxx Though the "loose" option was set to "false" in your @babel/preset-env config, it will not be used for @babel/plugin-proposal-private-property-in-object since the "loose" mode option was set to "true" for @babel/plugin-proposal-private-methods.
The "loose" option must be the same for @babel/plugin-proposal-class-properties, @babel/plugin-proposal-private-methods and @babel/plugin-proposal-private-property-in-object (when they are enabled): you can silence this warning by explicitly adding
 ["@babel/plugin-proposal-private-property-in-object", { "loose": true }]
```

# 動作確認
* `rm -rf node_modules/.cache/storybook` : キャッシュの削除
* `yarn storybook`

# 注意点
* 一度ビルド完了してしまうと、この警告は出ないのでキャッシュ削除してからでないと再現しません。

# その他
* 初めてPR出すので、ブランチ名とかコミットメッセージルールとか、間違ってる箇所があればコメントください。