### PR TITLE
react-isをインストール

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "jest-environment-jsdom": "^29.3.1",
     "openapi2aspida": "^0.21.0",
     "prettier": "^2.5.1",
+    "react-is": "^18.2.0",
     "ress": "^5.0.2",
     "styled-components": "^5.3.3",
     "typescript": "4.7.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12567,7 +12567,7 @@ react-is@^16.13.1, react-is@^16.7.0:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
 
-react-is@^18.0.0:
+react-is@^18.0.0, react-is@^18.2.0:
   version "18.2.0"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-18.2.0.tgz#199431eeaaa2e09f86427efbb4f1473edb47609b"
   integrity sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==


### PR DESCRIPTION
## 概要
yarn install時に以下の警告が出るので、react-isをインストールした
```
warning " > styled-components@5.3.10" has unmet peer dependency "react-is@>= 16.8.0".
```