### PR TITLE
openapi に関する修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,5 @@
 | storybook       | storybook の起動                                                   |
 | build-storybook | storybook のビルド                                                 |
 | mock            | mock サーバ起動（データ 1 件 または example に書いてあるもののみ） |
-| mock:many       | mock サーバ起動（データ件数たくさん）                              |
 | generate        | openapi.yaml を元に TypeScript の型と API クライアントを生成       |
 | test            | jest の実行                                                        |

--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build -s public",
     "mock": "prism mock schema/openapi.yaml -p 8080",
-    "mock:many": "yarn mock -d",
     "generate": "rm -rf api && openapi2aspida -i schema/openapi.yaml",
     "test": "jest"
   },

--- a/schema/openapi.yaml
+++ b/schema/openapi.yaml
@@ -5,7 +5,7 @@ info:
   description: yumeshopのAPIが定義されています。
   contact: {}
 servers:
-  - url: 'http://localhost:3000'
+  - url: 'http://localhost:8080'
     description: dev mock server
 tags:
   - name: shop_items


### PR DESCRIPTION
# 概要

#212 
ひとまず対応すべき範囲だけ対応しました

インターン中モック起動をどちらにすればいいか悩むが、`mock:many`よりも`mock`で起動した方がいいため、変更しました。
また、mockサーバーは8080番に立つため、servers.url も修正しました。

将来的には msw を導入したい。