### PR TITLE
yarn build でエラーが発生

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,5 +1,6 @@
 /** @type {import('next').NextConfig} */
 module.exports = {
+  pageExtensions: ['ts', 'tsx', 'mdx', 'test.tsx'],
   reactStrictMode: true,
   images: {
     remotePatterns: [


### PR DESCRIPTION
## 概要

* タイトル通り
* `pages` ディレクトリ以下に `*.test.tsx` があり，そのファイルがビルド時にコケてた
* [こちらのページ](https://nextjs.org/docs/app/api-reference/next-config-js/pageExtensions)を参考に変更

## チェック事項

* 各npm scriptsが問題なく動作すること
* 本当にバンドルに含まれていないのか？の確認